### PR TITLE
feat: use github refs instead of forks

### DIFF
--- a/depends_on_stage2
+++ b/depends_on_stage2
@@ -51,6 +51,7 @@ def extract_change(change_info, main_url, work_dir):
     fork_url = change_info["fork_url"]
     main_url = change_info["main_url"]
     main_branch = change_info["main_branch"]
+    pr_number = change_info["pr_number"]
     if is_gerrit(fork_url):
         return extract_gerrit_change(
             fork_url, change_info["branch"], main_branch, work_dir
@@ -64,7 +65,7 @@ def extract_change(change_info, main_url, work_dir):
             fork_url,
             change_info["branch"],
             main_url,
-            main_branch,
+            pr_number,
             work_dir,
         )
 

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ async function run() {
       description: description,
       fork_url: mainPR.head.repo.clone_url,
       branch: mainPR.head.ref,
+      pr_number: prNumber,
       main_url: mainPR.base.repo.clone_url,
       main_branch: mainPR.base.ref,
       change_url: mainPR.html_url,


### PR DESCRIPTION
be266d5 feat: use github refs instead of forks

commit be266d582dbcea2c6d301fec19dd3ab38784e85e
Author: Sébastien Han <seb@redhat.com>
Date:   Tue Dec 10 17:10:06 2024 +0100

    feat: use github refs instead of forks
    
    GitHub keeps refs for each PR that were ever sent to a repo. This is
    extremely useful, very reliable and remain almost forever.
    
    This handles the following cases:
    
    * the fork branch is gone
    * the fork is gone
    * the PR is closed
    
    Signed-off-by: Sébastien Han <seb@redhat.com>
