### PR TITLE
fix: enhance go.mod parsing

### DIFF
--- a/tests/test_go.py
+++ b/tests/test_go.py
@@ -1,0 +1,283 @@
+import pathlib
+
+import pytest
+
+import depends_on.golang as go
+
+
+@pytest.mark.parametrize(
+    "go_mod_content, expected_modules",
+    [
+        (
+            """
+module github.com/leseb/supertini-go
+
+go 1.16
+
+require gopkg.in/fsnotify/fsnotify.v1 v1.4.7
+require golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
+""",
+            ["gopkg.in/fsnotify/fsnotify.v1"],
+        ),
+        (
+            """
+        module github.com/leseb/supertini-go
+        go 1.16
+        require (
+                github.com/fsnotify/fsnotify v1.5.1 // indirect
+                golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f // indirect
+                gopkg.in/fsnotify/fsnotify.v1 v1.4.7
+        )
+        """,
+            ["gopkg.in/fsnotify/fsnotify.v1"],
+        ),
+        (
+            """
+        module github.com/rook/rook
+        go 1.22.5
+        toolchain go1.22.7
+        replace (
+        	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.1
+        	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v0.20.4-openstorage-rc3
+        	// TODO: remove this replace once https://github.com/libopenstorage/secrets/pull/83 is merged
+        	github.com/libopenstorage/secrets => github.com/rook/secrets v0.0.0-20240315053144-3195f6906937
+        	github.com/portworx/sched-ops => github.com/portworx/sched-ops v0.20.4-openstorage-rc3
+        	github.com/rook/rook/pkg/apis => ./pkg/apis
+        )
+        require (
+        	github.com/IBM/keyprotect-go-client v0.15.1
+        	github.com/aws/aws-sdk-go v1.55.5
+        	github.com/banzaicloud/k8s-objectmatcher v1.8.0
+        	github.com/ceph/ceph-csi-operator/api v0.0.0-20240918113437-f3030b0ac9f4
+        	github.com/ceph/go-ceph v0.29.0
+        	github.com/coreos/pkg v0.0.0-20230601102743-20bbbf26f4d8
+        	github.com/csi-addons/kubernetes-csi-addons v0.10.1-0.20240924092040-c11db0b867a1
+        	github.com/gemalto/kmip-go v0.0.10
+        	github.com/go-ini/ini v1.67.0
+        	github.com/google/go-cmp v0.6.0
+        	github.com/google/uuid v1.6.0
+        	github.com/hashicorp/vault/api v1.15.0
+        	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.3
+        	github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20221122204822-d1a8c34382f1
+        	github.com/libopenstorage/secrets v0.0.0-20240416031220-a17cf7f72c6c
+        	github.com/pkg/errors v0.9.1
+        	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.76.2
+        	github.com/prometheus-operator/prometheus-operator/pkg/client v0.76.2
+        	github.com/rook/rook/pkg/apis v0.0.0-20231204200402-5287527732f7
+        	github.com/sethvargo/go-password v0.3.1
+        	github.com/spf13/cobra v1.8.1
+        	github.com/spf13/pflag v1.0.5
+        	github.com/stretchr/testify v1.9.0
+        	github.com/sykesm/zap-logfmt v0.0.4
+        	go.uber.org/automaxprocs v1.6.0
+        	go.uber.org/zap v1.27.0
+        	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+        	golang.org/x/sync v0.10.0
+        	gopkg.in/ini.v1 v1.67.0
+        	gopkg.in/yaml.v2 v2.4.0
+        	k8s.io/api v0.31.2
+        	k8s.io/apiextensions-apiserver v0.31.2
+        	k8s.io/apimachinery v0.31.2
+        	k8s.io/cli-runtime v0.31.2
+        	k8s.io/client-go v0.31.2
+        	k8s.io/cloud-provider v0.31.2
+        	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8
+        	sigs.k8s.io/controller-runtime v0.19.1
+        	sigs.k8s.io/mcs-api v0.1.0
+        	sigs.k8s.io/yaml v1.4.0
+        )
+        require (
+        	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0 // indirect
+        	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0 // indirect
+        	github.com/Azure/azure-sdk-for-go/sdk/internal v1.9.0 // indirect
+        	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets v0.12.0 // indirect
+        	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
+        	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
+        	github.com/Masterminds/semver/v3 v3.2.1 // indirect
+        	github.com/blang/semver/v4 v4.0.0 // indirect
+        	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+        	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
+        	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
+        	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+        	github.com/kylelemons/godebug v1.1.0 // indirect
+        	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+        	github.com/portworx/sched-ops v1.20.4-rc1 // indirect
+        	github.com/x448/float16 v0.8.4 // indirect
+        	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+        )
+        require (
+        	emperror.dev/errors v0.8.1 // indirect
+        	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
+        	github.com/ansel1/merry v1.8.0 // indirect
+        	github.com/ansel1/merry/v2 v2.2.0 // indirect
+        	github.com/beorn7/perks v1.0.1 // indirect
+        	github.com/ceph/ceph-csi/api v0.0.0-20231227104434-06f9a98b7a83
+        	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+        	github.com/containernetworking/cni v1.2.0-rc1 // indirect
+        	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
+        	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+        	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
+        	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
+        	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
+        	github.com/fsnotify/fsnotify v1.7.0 // indirect
+        	github.com/gemalto/flume v0.13.1 // indirect
+        	github.com/go-errors/errors v1.5.1 // indirect
+        	github.com/go-logr/logr v1.4.2 // indirect
+        	github.com/go-logr/zapr v1.3.0 // indirect
+        	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+        	github.com/go-openapi/jsonreference v0.21.0 // indirect
+        	github.com/go-openapi/swag v0.23.0 // indirect
+        	github.com/gogo/protobuf v1.3.2 // indirect
+        	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+        	github.com/golang/protobuf v1.5.4 // indirect
+        	github.com/google/btree v1.1.2 // indirect
+        	github.com/google/gnostic-models v0.6.8 // indirect
+        	github.com/google/gofuzz v1.2.0 // indirect
+        	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+        	github.com/gorilla/websocket v1.5.0 // indirect
+        	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+        	github.com/hashicorp/errwrap v1.1.0 // indirect
+        	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+        	github.com/hashicorp/go-multierror v1.1.1 // indirect
+        	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+        	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+        	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.8 // indirect
+        	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+        	github.com/hashicorp/go-sockaddr v1.0.6 // indirect
+        	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
+        	github.com/hashicorp/vault/api/auth/approle v0.6.0 // indirect
+        	github.com/hashicorp/vault/api/auth/kubernetes v0.6.0 // indirect
+        	github.com/imdario/mergo v0.3.16 // indirect
+        	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+        	github.com/jmespath/go-jmespath v0.4.0 // indirect
+        	github.com/josharian/intern v1.0.0 // indirect
+        	github.com/json-iterator/go v1.1.12 // indirect
+        	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
+        	github.com/mailru/easyjson v0.7.7 // indirect
+        	github.com/mattn/go-colorable v0.1.13 // indirect
+        	github.com/mattn/go-isatty v0.0.20 // indirect
+        	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+        	github.com/mitchellh/go-homedir v1.1.0 // indirect
+        	github.com/mitchellh/mapstructure v1.5.0 // indirect
+        	github.com/moby/spdystream v0.4.0 // indirect
+        	github.com/moby/term v0.5.0 // indirect
+        	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+        	github.com/modern-go/reflect2 v1.0.2 // indirect
+        	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+        	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+        	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+        	github.com/openshift/api v0.0.0-20240301093301-ce10821dc999 // indirect
+        	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+        	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+        	github.com/prometheus/client_golang v1.19.1 // indirect
+        	github.com/prometheus/client_model v0.6.1 // indirect
+        	github.com/prometheus/common v0.55.0 // indirect
+        	github.com/prometheus/procfs v0.15.1 // indirect
+        	github.com/ryanuber/go-glob v1.0.0 // indirect
+        	github.com/sirupsen/logrus v1.9.3 // indirect
+        	github.com/stretchr/objx v0.5.2 // indirect
+        	github.com/xlab/treeprint v1.2.0 // indirect
+        	go.starlark.net v0.0.0-20231121155337-90ade8b19d09 // indirect
+        	go.uber.org/multierr v1.11.0 // indirect
+        	golang.org/x/crypto v0.26.0 // indirect
+        	golang.org/x/net v0.28.0 // indirect
+        	golang.org/x/oauth2 v0.22.0 // indirect
+        	golang.org/x/sys v0.24.0 // indirect
+        	golang.org/x/term v0.23.0 // indirect
+        	golang.org/x/text v0.17.0 // indirect
+        	golang.org/x/time v0.6.0 // indirect
+        	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
+        	google.golang.org/protobuf v1.34.2 // indirect
+        	gopkg.in/inf.v0 v0.9.1 // indirect
+        	gopkg.in/yaml.v3 v3.0.1 // indirect
+        	k8s.io/klog/v2 v2.130.1 // indirect
+        	k8s.io/kube-openapi v0.0.0-20240808142205-8e686545bdb8 // indirect
+        	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+        	sigs.k8s.io/kustomize/api v0.17.2 // indirect
+        	sigs.k8s.io/kustomize/kyaml v0.17.1 // indirect
+        	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
+        )
+        exclude (
+        	// exclude goproxy versions with security bugs
+        	github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e
+        	github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153
+        	github.com/elazarl/goproxy v0.0.0-20181111060418-2ce16c963a8a
+        	github.com/kubernetes-incubator/external-storage v0.20.4-openstorage-rc2
+        	// Exclude pre-go-mod kubernetes tags, because they are older
+        	// than v0.x releases but are picked when updating dependencies.
+        	k8s.io/client-go v1.4.0
+        	k8s.io/client-go v1.5.0
+        	k8s.io/client-go v1.5.1
+        	k8s.io/client-go v1.5.2
+        	k8s.io/client-go v2.0.0-alpha.1+incompatible
+        	k8s.io/client-go v2.0.0+incompatible
+        	k8s.io/client-go v3.0.0-beta.0+incompatible
+        	k8s.io/client-go v3.0.0+incompatible
+        	k8s.io/client-go v4.0.0-beta.0+incompatible
+        	k8s.io/client-go v4.0.0+incompatible
+        	k8s.io/client-go v5.0.0+incompatible
+        	k8s.io/client-go v5.0.1+incompatible
+        	k8s.io/client-go v6.0.0+incompatible
+        	k8s.io/client-go v7.0.0+incompatible
+        	k8s.io/client-go v8.0.0+incompatible
+        	k8s.io/client-go v9.0.0-invalid+incompatible
+        	k8s.io/client-go v9.0.0+incompatible
+        	k8s.io/client-go v10.0.0+incompatible
+        	k8s.io/client-go v11.0.0+incompatible
+        	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+        	k8s.io/client-go v12.0.0+incompatible
+        )
+        """,
+            [
+                "github.com/IBM/keyprotect-go-client",
+                "github.com/aws/aws-sdk-go",
+                "github.com/banzaicloud/k8s-objectmatcher",
+                "github.com/ceph/ceph-csi-operator/api",
+                "github.com/ceph/go-ceph",
+                "github.com/coreos/pkg",
+                "github.com/csi-addons/kubernetes-csi-addons",
+                "github.com/gemalto/kmip-go",
+                "github.com/go-ini/ini",
+                "github.com/google/go-cmp",
+                "github.com/google/uuid",
+                "github.com/hashicorp/vault/api",
+                "github.com/k8snetworkplumbingwg/network-attachment-definition-client",
+                "github.com/kube-object-storage/lib-bucket-provisioner",
+                "github.com/libopenstorage/secrets",
+                "github.com/pkg/errors",
+                "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring",
+                "github.com/prometheus-operator/prometheus-operator/pkg/client",
+                "github.com/rook/rook/pkg/apis",
+                "github.com/sethvargo/go-password",
+                "github.com/spf13/cobra",
+                "github.com/spf13/pflag",
+                "github.com/stretchr/testify",
+                "github.com/sykesm/zap-logfmt",
+                "go.uber.org/automaxprocs",
+                "go.uber.org/zap",
+                "golang.org/x/exp",
+                "golang.org/x/sync",
+                "gopkg.in/ini.v1",
+                "gopkg.in/yaml.v2",
+                "k8s.io/api",
+                "k8s.io/apiextensions-apiserver",
+                "k8s.io/apimachinery",
+                "k8s.io/cli-runtime",
+                "k8s.io/client-go",
+                "k8s.io/cloud-provider",
+                "k8s.io/utils",
+                "sigs.k8s.io/controller-runtime",
+                "sigs.k8s.io/mcs-api",
+                "sigs.k8s.io/yaml",
+                "github.com/ceph/ceph-csi/api",
+            ],
+        ),
+    ],
+)
+def test_get_modules(tmp_path: pathlib.Path, go_mod_content, expected_modules):
+    go_mod_path = tmp_path / "go.mod"
+    go_mod_path.write_text(go_mod_content)
+    result = go.get_modules(go_mod_path)
+
+    assert result is not None
+    assert result == expected_modules


### PR DESCRIPTION
The go modules parsing received a few improvements:

* does not restrict to testing github.com only packages
* proper support for single "require" and multi lines directives
* added unit tests

Fixes: https://github.com/depends-on/depends-on-action/issues/49
Signed-off-by: Sébastien Han <seb@redhat.com>