### PR TITLE
make: skip build if ncc is not available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,8 @@ package-lock.json: package.json
 	npm install
 
 dist/index.js: index.js package-lock.json
-	npm run build
+	if ! command -v ncc >/dev/null 2>&1; then \
+		echo "skip build since ncc is not available"; \
+	else \
+		npm run build; \
+	fi


### PR DESCRIPTION
If ncc is install we build the npm otherwise we skip.